### PR TITLE
Update cafe-main.js ln 276 to fix warning

### DIFF
--- a/UrbanRoast-tutorial/modules/module3/3-1/javascripts/cafe-main.js
+++ b/UrbanRoast-tutorial/modules/module3/3-1/javascripts/cafe-main.js
@@ -273,7 +273,9 @@ function loadViews(v) {
 
         for (var col = 0; col < numCol; col++) {
             for (var row = 0; row < numRow; row++) {
-                eachRow = data._dataset_internal_.levelDataNodes[0].detail.data[row][col];
+                //changing definition of eachRow as data couldn't be found in Chrome.
+                //eachRow = data._dataset_internal_.levelDataNodes[0].detail.data[row][col];
+                eachRow = data._dataset_internal_.levelDataNodes[0].all.children[0].detail.data[row][col];
                 if (col === 0) { nameData.push(eachRow) }
                 if (col === 0) { svgNameData.push(eachRow) }
                 if (col === 5) { cafData.push(eachRow) }


### PR DESCRIPTION
Changing the definition of variable 'eachRow' as .data couldn't be found in Chrome which was skipping the rest of the script and thus not displaying the page entirely.